### PR TITLE
Fix #2: Add Dark/Light Mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,28 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sydney Live Clock</title>
     <style>
+        :root {
+            --bg-gradient-start: #1a1a2e;
+            --bg-gradient-end: #16213e;
+            --container-bg: rgba(255, 255, 255, 0.1);
+            --text-primary: #fff;
+            --text-secondary: #a0a0a0;
+            --text-muted: #666;
+            --accent: #4ecdc4;
+            --shadow: rgba(0, 0, 0, 0.3);
+        }
+
+        .light-mode {
+            --bg-gradient-start: #f5f7fa;
+            --bg-gradient-end: #c3cfe2;
+            --container-bg: rgba(0, 0, 0, 0.05);
+            --text-primary: #1a1a2e;
+            --text-secondary: #555;
+            --text-muted: #777;
+            --accent: #2d9cdb;
+            --shadow: rgba(0, 0, 0, 0.1);
+        }
+
         body {
             font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
             display: flex;
@@ -12,21 +34,23 @@
             align-items: center;
             min-height: 100vh;
             margin: 0;
-            background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
-            color: #fff;
+            background: linear-gradient(135deg, var(--bg-gradient-start) 0%, var(--bg-gradient-end) 100%);
+            color: var(--text-primary);
+            transition: background 0.3s ease, color 0.3s ease;
         }
         .clock-container {
             text-align: center;
             padding: 2rem;
-            background: rgba(255, 255, 255, 0.1);
+            background: var(--container-bg);
             border-radius: 20px;
             backdrop-filter: blur(10px);
-            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+            box-shadow: 0 8px 32px var(--shadow);
+            transition: background 0.3s ease, box-shadow 0.3s ease;
         }
         h1 {
             font-size: 1.5rem;
             margin-bottom: 1rem;
-            color: #4ecdc4;
+            color: var(--accent);
         }
         .clock {
             font-size: 4rem;
@@ -34,19 +58,44 @@
             letter-spacing: 4px;
             text-shadow: 0 0 20px rgba(78, 205, 196, 0.5);
         }
+        .light-mode .clock {
+            text-shadow: 0 0 20px rgba(45, 156, 219, 0.4);
+        }
         .date {
             font-size: 1.2rem;
             margin-top: 0.5rem;
-            color: #a0a0a0;
+            color: var(--text-secondary);
         }
         .timezone {
             font-size: 0.9rem;
             margin-top: 1rem;
-            color: #666;
+            color: var(--text-muted);
+        }
+        .theme-toggle {
+            position: absolute;
+            top: 1rem;
+            right: 1rem;
+            background: var(--container-bg);
+            border: none;
+            border-radius: 50%;
+            width: 48px;
+            height: 48px;
+            cursor: pointer;
+            font-size: 1.5rem;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            transition: background 0.3s ease, transform 0.2s ease;
+            backdrop-filter: blur(10px);
+            box-shadow: 0 4px 12px var(--shadow);
+        }
+        .theme-toggle:hover {
+            transform: scale(1.1);
         }
     </style>
 </head>
 <body>
+    <button class="theme-toggle" id="themeToggle" title="Toggle dark/light mode">🌙</button>
     <div class="clock-container">
         <h1>🕐 Sydney, Australia</h1>
         <div class="clock" id="clock">--:--:--</div>
@@ -75,6 +124,22 @@
             document.getElementById('clock').textContent = time;
             document.getElementById('date').textContent = `${weekday}, ${date.split(', ').slice(1).join(', ')}`;
         }
+
+        // Theme toggle
+        const themeToggle = document.getElementById('themeToggle');
+        const savedTheme = localStorage.getItem('theme');
+        
+        if (savedTheme === 'light') {
+            document.body.classList.add('light-mode');
+            themeToggle.textContent = '☀️';
+        }
+
+        themeToggle.addEventListener('click', () => {
+            document.body.classList.toggle('light-mode');
+            const isLight = document.body.classList.contains('light-mode');
+            themeToggle.textContent = isLight ? '☀️' : '🌙';
+            localStorage.setItem('theme', isLight ? 'light' : 'dark');
+        });
 
         updateClock();
         setInterval(updateClock, 1000);


### PR DESCRIPTION
## Description
Implements a dark/light mode toggle for the Sydney Clock web application to address issue #2.

## Changes Made
- Added CSS custom properties (variables) for theming
- Created `.light-mode` class with light color scheme
- Added toggle button in top-right corner with sun/moon icons
- Persists user preference in localStorage
- Smooth transitions between themes

## Testing Instructions
1. Open the webpage in a browser
2. Click the moon icon (🌙) in the top-right corner to switch to light mode
3. Verify the background changes from dark blue gradient to light gray gradient
4. Verify text colors adapt appropriately
5. Refresh the page - the preference should persist
6. Click the sun icon (☀️) to switch back to dark mode
7. Check localStorage - should contain `theme: "dark"` or `theme: "light"`

## Screenshots
- Dark mode (default): Dark blue gradient background with white text
- Light mode: Light gray gradient with dark text