### PR TITLE
Fix #4: Time is not displaying

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,23 +57,28 @@
     <script>
         function updateClock() {
             // Sydney timezone: AEST = UTC+10
-            const sydneyTime = new Date().toLocaleString('en-AU', {
+            const now = new Date();
+            
+            // Get time in Sydney (AEST)
+            const sydneyTime = now.toLocaleString('en-AU', {
                 timeZone: 'Australia/Sydney',
                 hour: '2-digit',
                 minute: '2-digit',
                 second: '2-digit',
-                hour12: false,
+                hour12: false
+            });
+            
+            // Get date in Sydney
+            const sydneyDate = now.toLocaleString('en-AU', {
+                timeZone: 'Australia/Sydney',
                 weekday: 'long',
                 year: 'numeric',
                 month: 'long',
                 day: 'numeric'
             });
 
-            const [weekday, date] = sydneyTime.split(', ');
-            const [time] = date.split(', ');
-
-            document.getElementById('clock').textContent = time;
-            document.getElementById('date').textContent = `${weekday}, ${date.split(', ').slice(1).join(', ')}`;
+            document.getElementById('clock').textContent = sydneyTime;
+            document.getElementById('date').textContent = sydneyDate;
         }
 
         updateClock();


### PR DESCRIPTION
## Summary
The clock time was not displaying correctly due to a bug in how the toLocaleString output was being parsed.

## Root Cause
The original code used a single `toLocaleString()` call for both time and date, then attempted to extract the time using `split()`. However, the output format didn't match the assumptions in the split logic:

```javascript
const sydneyTime = new Date().toLocaleString('en-AU', {...});
const [weekday, date] = sydneyTime.split(', ');
const [time] = date.split(', '); // Bug: date is "22 February 2026", not "hours,minutes"
```

This resulted in the time element showing the date instead of the actual time.

## Fix
Made separate calls to `toLocaleString()` - one for time and one for date:

```javascript
// Get time in Sydney (AEST)
const sydneyTime = now.toLocaleString('en-AU', {
    timeZone: 'Australia/Sydney',
    hour: '2-digit',
    minute: '2-digit',
    second: '2-digit',
    hour12: false
});

// Get date in Sydney
const sydneyDate = now.toLocaleString('en-AU', {
    timeZone: 'Australia/Sydney',
    weekday: 'long',
    year: 'numeric',
    month: 'long',
    day: 'numeric'
});
```

## Testing Instructions
1. Open index.html in a browser
2. Verify the clock displays the current time in Sydney (AEST/UTC+10)
3. Verify the date displays correctly
4. Wait a few seconds to confirm the time updates every second

Closes #4